### PR TITLE
feat(Newsletter): added newsletter page

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/logo.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Vite + React + TS</title>
+    <title>Automa Automations</title>
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import LandingPage from "./pages/LandingPage";
 import Layout from "./pages/Layout";
+import Newsletter from "./pages/Newsletter";
 
 function App() {
   return (
@@ -8,6 +9,7 @@ function App() {
       <Routes>
         <Route path="/" element={<Layout />}>
           <Route index element={<LandingPage />} />
+          <Route path="newsletter" element={<Newsletter />} />
         </Route>
       </Routes>
     </BrowserRouter>

--- a/src/pages/LandingPage.tsx
+++ b/src/pages/LandingPage.tsx
@@ -10,7 +10,10 @@ import {
   createIcon,
 } from '@chakra-ui/react';
 
+import { useNavigate } from 'react-router-dom';
+
 export default function CallToActionWithAnnotation() {
+  const navigate = useNavigate();
   return (
     <>
       <Container maxW={'3xl'}>
@@ -44,7 +47,9 @@ export default function CallToActionWithAnnotation() {
               px={6}
               _hover={{
                 bg: 'green.500',
-              }}>
+              }}
+              onClick={() => navigate('/newsletter')}
+            >
               Get Started
             </Button>
             <Button variant={'link'} colorScheme={'blue'} size={'sm'}>

--- a/src/pages/Newsletter.tsx
+++ b/src/pages/Newsletter.tsx
@@ -1,0 +1,37 @@
+import { Button, Flex, Text } from "@chakra-ui/react";
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+
+export default function Newsletter() {
+  const newsletterUrl = "http://eepurl.com/iQrOkI"
+  const navigate = useNavigate()
+
+  useEffect(() => {
+    // open up new tab on this link: http://eepurl.com/iQrOkI
+    window.open(newsletterUrl, "_blank")
+  }, [])
+  return (
+    <Flex 
+      width="100%"
+      height="100vh"
+      alignItems="center"
+      justifyContent="center"
+      flexDirection="column"
+      gap="10px"
+    >
+      <Text 
+        fontSize="3xl"
+        fontWeight="bold"
+      >
+        Redirecting to newsletter... 
+      </Text>
+      <Flex
+        gap="10px"
+        alignItems="center"
+      >
+        <Button onClick={() => navigate(-1)}>Back</Button>
+        <Button colorScheme="blue" onClick={() => window.open(newsletterUrl, "_blank")}>Join our newsletter</Button>
+      </Flex>
+    </Flex>
+  )
+}


### PR DESCRIPTION
Added newsletter page, which will navigate user to Mailchimp form. There is a back button and a "Join our newsletter" button in case the it didn't navigate for the user. On landing page, the get started button takes the user to the newsletter route.

## Context:

Gather the emails of user easily. That is the point of the form.

## Changes:
1. Added newsletter route, which opens new tab to Mailchimp form.
2. "Get started" button on landing page routes to newsletter page.

## Test plan:
Just clone it, and test. Quite easy to do, React Vite projects.

## Steps:
1. Clone repo.
2. install modules, start web app.
3. click on "Get started" button. Everything works.

## Results:
![image](https://github.com/Automa-Automations/web-app/assets/141557971/e958fcb9-f663-4553-950d-1a93e68d8f57)
![image](https://github.com/Automa-Automations/web-app/assets/141557971/8490042c-1203-4c88-aa39-d5777112cd9a)
![image](https://github.com/Automa-Automations/web-app/assets/141557971/81a62744-0089-406d-a243-e84654e816ef)
